### PR TITLE
v1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # endpoint-routing
 
-![Version](https://img.shields.io/badge/Version-1.0.3-brightgreen)
+![Version](https://img.shields.io/badge/Version-1.0.4-brightgreen)
 
 A directory-based HTTP request router.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # endpoint-routing
 
-![Version](https://img.shields.io/badge/Version-1.0.4-brightgreen)
+![Version](https://img.shields.io/badge/Version-1.0.5-brightgreen)
 
 A directory-based HTTP request router.
 

--- a/lib/making-requests.js
+++ b/lib/making-requests.js
@@ -41,6 +41,39 @@ function endpointRouting(args) {
 }
 
 /**
+ * Take the supposed contents of a route config JSON file, and extract relevant information about endpoint paths,
+ * compilation versions, etc.
+ * 
+ * @param {Object} routeConfig The output from the routes config JSON file.
+ * @returns {Object} The extracted or assumed information about the provided compiled routes in this format:
+ * 
+ * ```
+ * {
+ *     routeAlgVersion: [Number]
+ *     routeRegistry: [Object]
+ * }
+ * ```
+ */
+function interpretRouteConfigContents(routeConfig) {
+    let routeAlgVersion;
+    let routeRegistry;
+
+    // Check if the JSON is more hierarchical
+    // If things like a version marker and routes are not defined, assume we're working with an OG compilation
+    if (!routeConfig.hasOwnProperty('routes')) {
+        // Old compilation
+        routeAlgVersion = 1;
+        routeRegistry = routeConfig;
+    } else {
+        // More recent compilation
+        routeAlgVersion = routeConfig['version'];
+        routeRegistry = routeConfig['routes'];
+    }
+
+    return { routeAlgVersion: routeAlgVersion, routeRegistry: routeRegistry };
+}
+
+/**
  * A handler class to assist with preforming HTTP requests to specific endpoints with specific methods.
  */
 class EndpointRouting {
@@ -50,8 +83,7 @@ class EndpointRouting {
     #allowedMethods;
 
     constructor(handlersDir, routeConfig, allowedMethods) {
-        const routeAlgVersion = routeConfig['version'];
-        const routeRegistry = routeConfig['routes'];
+        const { routeAlgVersion, routeRegistry } = interpretRouteConfigContents(routeConfig);
 
         this.#handlersDir = handlersDir;
         this.#routeAlgVersion = routeAlgVersion;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
-import { promises as fsPromises } from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 /**
  * Resolves and validates a file or directory path based on specified constraints.
@@ -96,7 +96,10 @@ function readJSONFileSync(dir) {
  * @returns {Object} Returns the content of the package.json file formatted as a JSON object.
  */
 function readNodePackageJSONFile() {
-	return readJSONFileSync("./package.json");
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+    const packagePath = path.join(__dirname, '../package.json');
+	return readJSONFileSync(packagePath);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "endpoint-routing",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "route-alg-version": 1,
   "description": "A directory-based HTTP request router.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "endpoint-routing",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "route-alg-version": 1,
   "description": "A directory-based HTTP request router.",
   "main": "index.js",


### PR DESCRIPTION
Nothing major. More so just provided better handling of relative paths and checking of data integrity.

* Ensured that requests to files within the package, such as it's own package.json file, are relative to the package and not the project directory
* Request makers can handle both old and new compiled route files, with either just routes or more metadata contained within the file respectively